### PR TITLE
Bump postcss dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "publish-please": "^2.2.0"
   },
   "compatibleProcessors": {
-    "postcss": "^5.2.12",
+    "postcss": "^6.0.0",
     "node-sass": "^3.4.2 || ^4.5.0",
     "less": "^2.7.2"
   },

--- a/test/processor-postcss-test.js
+++ b/test/processor-postcss-test.js
@@ -8,7 +8,7 @@ describe('Processor: postcss', function() {
 
 	before(function*() {
 		this.timeout(0)
-		yield npm.install('postcss@5.0.14')
+		yield npm.install('postcss@6.0.6')
 		yield npm.install('autoprefixer')
 	})
 


### PR DESCRIPTION
Fixes #36 

`npm run test` output:

```
cosmin@aiur: ember-cli-css-preprocess master$ npm run test

> ember-cli-css-preprocess@1.1.0 test /home/cosmin/Cloud/Open Source/files/ember-cli-css-preprocess
> gulp test

[11:03:13] Using gulpfile ~/Cloud/Open Source/files/ember-cli-css-preprocess/gulpfile.js
[11:03:13] Starting 'test'...


  Module: loadProcessor
    ✓ can not load a processor that is not supported
    ✓ can not load a processor that is supported but not installed
    ✓ can load a processor that is installed and supported (15167ms)
    ✓ can not load a processor that is supported but has an non matching version (16224ms)

  Class: StyleProcessor
    ✓ can be instantiated
    can check if a file should be processed by a style processor
      ✓ no filter
      ✓ string which equals filename
      ✓ string which not equals filename
      ✓ glob string that matches filename
      ✓ glob string that does not match filename
      ✓ array with string that matches filename
      ✓ array with glob string that does not match filename
      ✓ array with additional negation
      ✓ array with additional affirmation

  Processor: node-sass
    ✓ can return a process-function (146ms)
    ✓ can process data

  Processor: postcss
    ✓ can return a process-function
    ✓ can process data (367ms)

  Processor: less
    ✓ can return a process-function
    ✓ can process data


  20 passing (2m)

[11:04:50] Finished 'test' after 1.62 min
```